### PR TITLE
Fixed Interface::send not working with candleLight devices

### DIFF
--- a/driver/src/device/gsusb.rs
+++ b/driver/src/device/gsusb.rs
@@ -197,7 +197,11 @@ impl HostFrame {
         data.push(self.channel);
         data.push(self.flags);
         data.push(self.reserved);
-        data.extend_from_slice(&self.data);
+        if ((self.flags & GS_CAN_FLAG_FD) != 0 || self.can_dlc > 8) {
+            data.extend_from_slice(&self.data);
+        } else { // legacy gs_host_frame is limited to 8 bytes of data
+            data.extend_from_slice(&self.data[..8]);
+        }
         data
     }
 }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -97,7 +97,8 @@ pub struct Frame {
 impl Frame {
     fn data_as_array(&self) -> [u8; 64] {
         let mut data = [0u8; 64];
-        data[..64].clone_from_slice(&self.data[..64]);
+        let len = std::cmp::min(self.data.len(), data.len());
+        data[..len].copy_from_slice(&self.data[..len]);
         data
     }
     // convert to a frame format expected by the device

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -122,7 +122,7 @@ impl Frame {
 
         HostFrame {
             echo_id: 1,
-            flags: 0,
+            flags: if self.fd { GS_CAN_FLAG_FD } else { 0 },
             reserved: 0,
             can_id,
             can_dlc: self.can_dlc,


### PR DESCRIPTION
candleLight devices only accept 8 bytes of data, and sending them 64 bytes completely stalls any transmission until power cycled. This fix slices data down to the first 8 bytes unless the FD flag is present or the DLC is greater than 8.